### PR TITLE
Pull/move plan sync to model

### DIFF
--- a/lib/chargebee_rails.rb
+++ b/lib/chargebee_rails.rb
@@ -11,13 +11,15 @@ require "chargebee_rails/subscription_builder"
 require "chargebee_rails/hosted_page_subscription_manager"
 require "chargebee_rails/customer"
 require "chargebee_rails/metered_billing"
+require "chargebee_rails/sync_plans"
+
 
 module ChargebeeRails
   # This method is used to update the chargebee customer and also reflects the
   # changes to the subscription owner in the application.
   # * *Args*    :
   #   - +customer+ -> the subscription owner
-  #   - +options+ -> the options hash allowed for customer update in chargebee 
+  #   - +options+ -> the options hash allowed for customer update in chargebee
   # For more details on the options hash, refer the input parameters for
   # https://apidocs.chargebee.com/docs/api/customers?lang=ruby#update_a_customer
   # * *Returns* :
@@ -32,11 +34,11 @@ module ChargebeeRails
   end
 
   # Update the billing information of the chargebee customer. The changes in the
-  # billing details are also reflected in the subscription owner's 
-  # +chargebee_customer_data+ 
+  # billing details are also reflected in the subscription owner's
+  # +chargebee_customer_data+
   # * *Args*    :
   #   - +customer+ -> the subscription owner
-  #   - +options+ -> the options hash allowed for updating customer billing info in chargebee 
+  #   - +options+ -> the options hash allowed for updating customer billing info in chargebee
   # For more details on the options hash, refer the input parameters for
   # https://apidocs.chargebee.com/docs/api/customers?lang=ruby#update_billing_info_for_a_customer
   # * *Returns* :
@@ -50,11 +52,11 @@ module ChargebeeRails
     customer
   end
 
-  # Add contacts to a chargebee customer, the subscription owner 
+  # Add contacts to a chargebee customer, the subscription owner
   # and the contact details hash is given as options.
   # * *Args*    :
   #   - +customer+ -> the subscription owner
-  #   - +options+ -> the options hash allowed for adding contacts to customer in chargebee 
+  #   - +options+ -> the options hash allowed for adding contacts to customer in chargebee
   # For more details on the options hash, refer the input parameters for
   # https://apidocs.chargebee.com/docs/api/customers?lang=ruby#add_contacts_to_a_customer
   # * *Returns* :
@@ -71,7 +73,7 @@ module ChargebeeRails
   # subscription owner
   # * *Args*    :
   #   - +customer+ -> the subscription owner
-  #   - +options+ -> the options hash allowed for updating customer contacts in chargebee 
+  #   - +options+ -> the options hash allowed for updating customer contacts in chargebee
   # For more details on the options hash, refer the input parameters for
   # https://apidocs.chargebee.com/docs/api/customers?lang=ruby#update_contacts_for_a_customer
   # * *Returns* :

--- a/lib/chargebee_rails/sync_plans.rb
+++ b/lib/chargebee_rails/sync_plans.rb
@@ -1,0 +1,83 @@
+module ChargebeeRails
+  class SyncPlans
+
+  	def self.sync
+  		syncer = SyncPlans.new
+  		syncer.do_sync
+  	end
+
+  	def do_sync
+  		self.get_plans
+  		self.sync_plans
+  	end
+
+  protected
+
+  def get_plans
+      loop do
+        plan_list = retrieve_plan_list
+        @offset = plan_list.next_offset
+        cb_plans << plan_list.flat_map(&:plan)
+        break unless @offset.present?
+      end
+      @cb_plans = cb_plans.flatten
+  end
+
+  def cb_plans
+    @cb_plans ||= []
+  end
+
+  def sync_plans
+    # puts "Removed #{remove_plans.count} plan(s)"
+    puts "Created #{create_new_plans.count} plan(s)"
+    puts "Updated all #{update_all_plans.count} plan(s)"
+  end
+
+  # Retrieve the plan list from chargebee
+  def retrieve_plan_list
+    options = { limit: 100 }
+    options[:offset] = @offset if @offset.present?
+    ChargeBee::Plan.list(options)
+  end
+
+  # Remove plans from application that do not exist in chargebee
+  def remove_plans
+    cb_plan_ids = cb_plans.flat_map(&:id)
+    Plan.all.reject { |plan| cb_plan_ids.include?(plan.plan_id) }
+            .each   { |plan| puts "Deleting Plan - #{plan.plan_id}"; plan.destroy }
+  end
+
+  # Create new plans that are not present in app but are available in chargebee
+  def create_new_plans
+    plan_ids = Plan.all.map(&:plan_id)
+    cb_plans.reject { |cb_plan| plan_ids.include?(cb_plan.id) }
+            .each   { |new_plan| puts "Creating Plan - #{new_plan.id}"; Plan.create(plan_params(new_plan)) }
+  end
+
+  # Update all existing plans in the application
+  def update_all_plans
+    cb_plans.map do |cb_plan|
+      Plan.find_by(plan_id: cb_plan.id).update(plan_params(cb_plan))
+    end
+  end
+
+  # Build the plan params to be created or updated in the application
+  def plan_params plan
+    {
+      name: plan.name,
+      plan_id: plan.id,
+      status: plan.status,
+      chargebee_data: {
+        price: plan.price,
+        period: plan.period,
+        period_unit: plan.period_unit,
+        trial_period: plan.trial_period,
+        trial_period_unit: plan.trial_period_unit,
+        charge_model: plan.charge_model,
+        free_quantity: plan.free_quantity
+      }
+    }
+  end
+
+  end
+end

--- a/lib/chargebee_rails/sync_plans.rb
+++ b/lib/chargebee_rails/sync_plans.rb
@@ -2,14 +2,14 @@ module ChargebeeRails
   class SyncPlans
     attr_accessor :messages
 
-  	def self.sync
+  	def self.sync(create:true, update:true, delete:false)
   		syncer = SyncPlans.new
-  		return syncer.do_sync
+  		return syncer.do_sync(create:create, update:update, delete:delete)
   	end
 
-  	def do_sync
+  	def do_sync(create:true, update:true, delete:false)
   		self.get_plans
-  		self.sync_plans
+  		self.sync_plans(create:create, update:update, delete:delete)
 
       return messages
   	end
@@ -36,10 +36,10 @@ module ChargebeeRails
     @cb_plans ||= []
   end
 
-  def sync_plans
-    # output "Removed #{remove_plans.count} plan(s)"
-    output "Created #{create_new_plans.count} plan(s)"
-    output "Updated all #{update_all_plans.count} plan(s)"
+  def sync_plans(create:true, update:true, delete:false)
+    output "Removed #{remove_plans.count} plan(s)" if (delete)
+    output "Created #{create_new_plans.count} plan(s)" if (create)
+    output "Updated all #{update_all_plans.count} plan(s)" if (update)
   end
 
   # Retrieve the plan list from chargebee

--- a/lib/tasks/sync_plans.rake
+++ b/lib/tasks/sync_plans.rake
@@ -1,4 +1,7 @@
+require 'chargebee_rails/sync_plans'
+
 namespace :chargebee_rails do
+  #include ChargebeeRails#
 
   desc "chargebee plans sync with application"
   task :sync_plans => :environment do
@@ -8,75 +11,10 @@ namespace :chargebee_rails do
       input = STDIN.gets.strip.downcase
     end until %w(y n).include?(input)
     if input == "y"
-      # Keep collecting the plans from chargebee until an offset is not provided
-      loop do
-        plan_list = retrieve_plan_list
-        @offset = plan_list.next_offset
-        cb_plans << plan_list.flat_map(&:plan)
-        break unless @offset.present?
-      end
-      @cb_plans = cb_plans.flatten
-      sync_plans
+      ChargebeeRails::SyncPlans.sync
     else
       STDOUT.puts "Plan sync aborted!"
     end
   end
 
-  private
-
-  def cb_plans
-    @cb_plans ||= []
-  end
-
-  def sync_plans
-    # puts "Removed #{remove_plans.count} plan(s)"
-    puts "Created #{create_new_plans.count} plan(s)"
-    puts "Updated all #{update_all_plans.count} plan(s)"
-  end
-
-  # Retrieve the plan list from chargebee
-  def retrieve_plan_list
-    options = { limit: 100 }
-    options[:offset] = @offset if @offset.present?
-    ChargeBee::Plan.list(options)
-  end
-
-  # Remove plans from application that do not exist in chargebee
-  def remove_plans
-    cb_plan_ids = cb_plans.flat_map(&:id)
-    Plan.all.reject { |plan| cb_plan_ids.include?(plan.plan_id) }
-            .each   { |plan| puts "Deleting Plan - #{plan.plan_id}"; plan.destroy }
-  end
-
-  # Create new plans that are not present in app but are available in chargebee
-  def create_new_plans
-    plan_ids = Plan.all.map(&:plan_id)
-    cb_plans.reject { |cb_plan| plan_ids.include?(cb_plan.id) }
-            .each   { |new_plan| puts "Creating Plan - #{new_plan.id}"; Plan.create(plan_params(new_plan)) }
-  end
-
-  # Update all existing plans in the application
-  def update_all_plans
-    cb_plans.map do |cb_plan|
-      Plan.find_by(plan_id: cb_plan.id).update(plan_params(cb_plan))
-    end
-  end
-
-  # Build the plan params to be created or updated in the application
-  def plan_params plan
-    {
-      name: plan.name,
-      plan_id: plan.id,
-      status: plan.status,
-      chargebee_data: {
-        price: plan.price,
-        period: plan.period,
-        period_unit: plan.period_unit,
-        trial_period: plan.trial_period,
-        trial_period_unit: plan.trial_period_unit,
-        charge_model: plan.charge_model,
-        free_quantity: plan.free_quantity
-      }
-    }
-  end
 end

--- a/lib/tasks/sync_plans.rake
+++ b/lib/tasks/sync_plans.rake
@@ -5,16 +5,7 @@ namespace :chargebee_rails do
 
   desc "chargebee plans sync with application"
   task :sync_plans => :environment do
-    # Prompt user input to get confirmation of the plan sync
-    begin
-      STDOUT.puts "\n This will sync plans in your application with chargebee, do you want to continue ? [y/n]"
-      input = STDIN.gets.strip.downcase
-    end until %w(y n).include?(input)
-    if input == "y"
-      ChargebeeRails::SyncPlans.sync
-    else
-      STDOUT.puts "Plan sync aborted!"
-    end
+    ChargebeeRails::SyncPlans.sync
   end
 
 end


### PR DESCRIPTION
this leaves the rake task completely unchanged in terms of functionality, but moves the logic to a class which can be accessed directly from within an app

e.g. in my app, I have a button in the admin area which says 'sync plans'
it also adds functionality to allow add/delete/update. By default, this is the same as the rake task.


note - I think the paramaw changes will disappear when/if you accept my pull request containing those commits