### PR TITLE
Pull/remove scheduled changes

### DIFF
--- a/app/controllers/chargebee_rails/webhooks_controller.rb
+++ b/app/controllers/chargebee_rails/webhooks_controller.rb
@@ -1,7 +1,7 @@
 module ChargebeeRails
   class WebhooksController < ActionController::Base
     include WebhookHandler
-    before_filter :authenticate, if: "ChargebeeRails.configuration.secure_webhook_api"
+    before_action :authenticate, if: "ChargebeeRails.configuration.secure_webhook_api"
 
     # Handle ChargeBee webhook events
     # From the post request received from chargebee, the event for which the

--- a/app/controllers/chargebee_rails/webhooks_controller.rb
+++ b/app/controllers/chargebee_rails/webhooks_controller.rb
@@ -1,7 +1,7 @@
 module ChargebeeRails
   class WebhooksController < ActionController::Base
     include WebhookHandler
-    before_action :authenticate, if: "ChargebeeRails.configuration.secure_webhook_api"
+    before_action :authenticate, if: :chargebee_configuration_webhook
 
     # Handle ChargeBee webhook events
     # From the post request received from chargebee, the event for which the
@@ -19,6 +19,10 @@ module ChargebeeRails
     end
 
     private
+
+    def chargebee_configuration_webhook
+      ChargebeeRails.configuration.secure_webhook_api
+    end
 
     def log_errors(e)
       logger.error e.message

--- a/lib/chargebee_rails/subscription.rb
+++ b/lib/chargebee_rails/subscription.rb
@@ -52,6 +52,21 @@ module ChargebeeRails
     end
 
     #
+    # Remove scheduled changes to the subscription
+    #
+    def remove_scheduled_changes
+      begin
+      chargebee_subscription = ChargeBee::Subscription.remove_scheduled_changes(
+        chargebee_id
+      ).subscription
+      update(subscription_attrs(chargebee_subscription, self.plan))
+      rescue ChargeBee::InvalidRequestError
+        Rails.logger.warn("No changes are scheduled for this subscription")
+      end
+
+    end
+
+    #
     # Add or remove addons for the subscription
     # * *Args*    :
     #   - +addon_id+ -> the id of addon in chargebee

--- a/lib/chargebee_rails/webhook_handler.rb
+++ b/lib/chargebee_rails/webhook_handler.rb
@@ -58,6 +58,26 @@ module ChargebeeRails
 
     def subscription_created; end
 
+    def subscription_started; end
+
+    def subscription_trial_end_reminder; end
+
+    def subscription_activated; end
+
+    def subscription_changed; end
+
+    def subscription_cancellation_scheduled; end
+
+    def subscription_cancellation_reminder; end
+
+    def subscription_cancelled; end
+
+    def subscription_reactivated; end
+
+    def subscription_renewed; end
+
+    def subscription_scheduled_cancellation_removed; end
+
     def subscription_shipping_address_updated; end
 
     def subscription_deleted; end
@@ -78,6 +98,8 @@ module ChargebeeRails
 
     def credit_note_deleted; end
 
+    def subscription_renewal_reminder; end
+
     def transaction_created; end
 
     def transaction_updated; end
@@ -97,6 +119,12 @@ module ChargebeeRails
     def netd_payment_due_reminder; end
 
     def card_added; end
+
+    def card_updated; end
+
+    def card_expiry_reminder; end
+
+    def card_expired; end
 
     def card_deleted; end
 

--- a/lib/chargebee_rails/webhook_handler.rb
+++ b/lib/chargebee_rails/webhook_handler.rb
@@ -14,7 +14,37 @@ module ChargebeeRails
       @event ||= @chargebee_event
     end
 
-    # All the event types in ChargeBee
+    # All the event types in ChargeBee as of API V2
+
+    def plan_created; end
+
+    def plan_updated; end
+
+    def plan_deleted; end
+
+    def addon_created; end
+
+    def addon_updated; end
+
+    def addon_deleted; end
+
+    def coupon_created; end
+
+    def coupon_updated; end
+
+    def coupon_deleted; end
+
+    def coupon_set_created; end
+
+    def coupon_set_updated; end
+
+    def coupon_set_deleted; end
+
+    def coupon_codes_added; end
+
+    def coupon_codes_deleted; end
+
+    def coupon_codes_updated; end
 
     def customer_created; end
 
@@ -22,27 +52,11 @@ module ChargebeeRails
 
     def customer_deleted; end
 
+    def customer_moved_out; end
+
+    def customer_moved_in; end
+
     def subscription_created; end
-
-    def subscription_started; end
-
-    def subscription_trial_end_reminder; end
-
-    def subscription_activated; end
-
-    def subscription_changed; end
-
-    def subscription_cancellation_scheduled; end
-
-    def subscription_cancellation_reminder; end
-
-    def subscription_cancelled; end
-
-    def subscription_reactivated; end
-
-    def subscription_renewed; end
-
-    def subscription_scheduled_cancellation_removed; end
 
     def subscription_shipping_address_updated; end
 
@@ -61,10 +75,8 @@ module ChargebeeRails
     def credit_note_created; end
 
     def credit_note_updated; end
-    
-    def credit_note_deleted; end
 
-    def subscription_renewal_reminder; end
+    def credit_note_deleted; end
 
     def transaction_created; end
 
@@ -79,18 +91,29 @@ module ChargebeeRails
     def payment_refunded; end
 
     def payment_initiated; end
-    
+
     def refund_initiated; end
-    
+
+    def netd_payment_due_reminder; end
+
     def card_added; end
 
-    def card_updated; end
-
-    def card_expiry_reminder; end
-
-    def card_expired; end
-
     def card_deleted; end
+
+    def payment_source_added; end
+
+    def payment_source_updated; end
+
+    def payment_source_deleted; end
+
+    def unbilled_charges_created; end
+
+    def unbilled_charges_voided; end
+
+    def unbilled_charges_deleted; end
+
+    def unbilled_charges_invoiced; end
+
 
     private
 
@@ -141,7 +164,7 @@ module ChargebeeRails
         plan_id: ::Plan.find_by(plan_id: subscription.plan_id).id,
         plan_quantity: subscription.plan_quantity,
         status: subscription.status,
-        event_last_modified_at: event.occurred_at,
+        event_last_modified_at: Time.at(event.occurred_at),
         updated_at: Time.now,
         chargebee_data: chargebee_subscription_data(subscription)
       }
@@ -166,7 +189,7 @@ module ChargebeeRails
         card_last4: card.last4,
         card_type: card.card_type,
         status: customer.payment_method.status,
-        event_last_modified_at: event.occurred_at,
+        event_last_modified_at: Time.at(event.occurred_at),
         updated_at: Time.now
       }
     end

--- a/lib/chargebee_rails/webhook_handler.rb
+++ b/lib/chargebee_rails/webhook_handler.rb
@@ -204,7 +204,8 @@ module ChargebeeRails
         next_renewal_at: subscription.current_term_end,
         cancelled_at: subscription.cancelled_at,
         is_scheduled_for_cancel: (subscription.status == 'non-renewing' ? true : false),
-        has_scheduled_changes: subscription.has_scheduled_changes
+        has_scheduled_changes: subscription.has_scheduled_changes,
+        addons: subscription.addons
       }
     end
 

--- a/lib/tasks/sync_plans.rake
+++ b/lib/tasks/sync_plans.rake
@@ -29,7 +29,7 @@ namespace :chargebee_rails do
   end
 
   def sync_plans
-    puts "Removed #{remove_plans.count} plan(s)"
+    # puts "Removed #{remove_plans.count} plan(s)"
     puts "Created #{create_new_plans.count} plan(s)"
     puts "Updated all #{update_all_plans.count} plan(s)"
   end

--- a/lib/tasks/sync_plans.rake
+++ b/lib/tasks/sync_plans.rake
@@ -29,9 +29,9 @@ namespace :chargebee_rails do
   end
 
   def sync_plans
-    # puts "Removed #{remove_plans.count} plan(s)"
+    puts "Removed #{remove_plans.count} plan(s)"
     puts "Created #{create_new_plans.count} plan(s)"
-    # puts "Updated all #{update_all_plans.count} plan(s)"
+    puts "Updated all #{update_all_plans.count} plan(s)"
   end
 
   # Retrieve the plan list from chargebee


### PR DESCRIPTION
this lets you remove scheduled changes on a subscription.

I use a scheduled change when the billing-count goes down to update at the end of the month.
If that changes mid-month, it is useful to get rid of a scheduled change

note - I think the paramaw changes will disappear when/if you accept my pull request containing those commits