### PR TITLE
Migration Bug/Compat Fixes

### DIFF
--- a/app/controllers/chargebee_rails/webhooks_controller.rb
+++ b/app/controllers/chargebee_rails/webhooks_controller.rb
@@ -1,7 +1,11 @@
 module ChargebeeRails
   class WebhooksController < ActionController::Base
     include WebhookHandler
-    before_filter :authenticate, if: "ChargebeeRails.configuration.secure_webhook_api"
+    if ActionPack::VERSION::MAJOR >= 5
+      before_action :authenticate, if: "ChargebeeRails.configuration.secure_webhook_api"
+    else
+      before_filter :authenticate, if: "ChargebeeRails.configuration.secure_webhook_api"
+    end
 
     # Handle ChargeBee webhook events
     # From the post request received from chargebee, the event for which the

--- a/lib/generators/chargebee_rails/install_generator.rb
+++ b/lib/generators/chargebee_rails/install_generator.rb
@@ -2,6 +2,7 @@
 # https://www.github.com/sferik/rails_admin/master/lib/generators/rails_admin/install_generator.rb
 
 require 'rails/generators'
+require 'rails/generators/active_record/migration'
 
 # http://guides.rubyonrails.org/generators.html
 
@@ -9,6 +10,7 @@ module ChargebeeRails
   class InstallGenerator < Rails::Generators::Base
 
     include Rails::Generators::Migration
+    include ActiveRecord::Generators::Migration
 
     argument :subscriber_model, :type => :string, :required => true, :desc => "Owner of the subscription"
     desc "ChargebeeRails installation generator"
@@ -16,11 +18,6 @@ module ChargebeeRails
     # The path for the custom migration templates
     def self.source_paths
       [File.expand_path("../templates", __FILE__)]
-    end
-
-    # Next migration number
-    def self.next_migration_number(dirname)
-      ActiveRecord::Generators::Base.next_migration_number(dirname)
     end
 
     # Override subscriber_model to ensure it is always returned lowercase.

--- a/lib/generators/chargebee_rails/install_generator.rb
+++ b/lib/generators/chargebee_rails/install_generator.rb
@@ -19,8 +19,8 @@ module ChargebeeRails
     end
 
     # Next migration number
-    def self.next_migration_number(dir)
-      Time.now.utc.strftime("%Y%m%d%H%M%S")
+    def self.next_migration_number(dirname)
+      ActiveRecord::Generators::Base.next_migration_number(dirname)
     end
 
     # Override subscriber_model to ensure it is always returned lowercase.

--- a/lib/generators/chargebee_rails/install_generator.rb
+++ b/lib/generators/chargebee_rails/install_generator.rb
@@ -32,7 +32,7 @@ module ChargebeeRails
 
       # Generate plan.
       generate("model", "plan name:string plan_id:string status:string chargebee_data:text")
-      template "app/models/plan.rb"
+      template "app/models/plan.rb", force: true
 
       # Generate subscription.
       migration_template "new_subscription_migration.rb", "db/migrate/create_subscriptions.rb"

--- a/lib/generators/chargebee_rails/templates/event_sync_log_migration.rb
+++ b/lib/generators/chargebee_rails/templates/event_sync_log_migration.rb
@@ -1,4 +1,10 @@
-class CreateEventSyncLog < ActiveRecord::Migration
+migration_superclass = if ActiveRecord::VERSION::MAJOR >= 5
+  ActiveRecord::Migration[4.2]
+else
+  ActiveRecord::Migration
+end
+
+class CreateEventSyncLog < migration_superclass
   def change
     create_table :event_sync_logs do |t|
 

--- a/lib/generators/chargebee_rails/templates/new_subscription_migration.rb
+++ b/lib/generators/chargebee_rails/templates/new_subscription_migration.rb
@@ -1,4 +1,10 @@
-class CreateSubscriptions < ActiveRecord::Migration
+migration_superclass = if ActiveRecord::VERSION::MAJOR >= 5
+  ActiveRecord::Migration[4.2]
+else
+  ActiveRecord::Migration
+end
+
+class CreateSubscriptions < migration_superclass
   def change
     create_table :subscriptions do |t|
       t.string :chargebee_id


### PR DESCRIPTION
The technique below fixes the issue described here -- https://github.com/spritlesoftware/chargebee-rails-subscriptions/issues/16

```
migration_superclass = if ActiveRecord::VERSION::MAJOR >= 5
  ActiveRecord::Migration[4.2]
else
  ActiveRecord::Migration
end
```

The changes in `install_generator.rb` fix an issue where migrations are generated so quickly that they end up with the same timestamp, preventing the migration from running. The necessary module exists in Rails 4.2.4 -- https://github.com/rails/rails/blob/v4.2.4/activerecord/lib/rails/generators/active_record/migration.rb

Also, by adding `force: true` we prevent prompting the user for conflict resolution when we template over the automatically generated rails model from the line above.